### PR TITLE
Improve error message when getting partition info.

### DIFF
--- a/lib/eventhub.js
+++ b/lib/eventhub.js
@@ -42,12 +42,18 @@ function EventHubInstance(ns, name, user, pass, amqpProvider) {
             callback(null, result);
           });
         } else {
-        
-          var code = null;
-          if(response && response.hasOwnProperty('statusCode')) {
-            code = response.statusCode;
+          if (err) {
+            callback(err, null);
+          } else {
+            var errorMessage = 'Unable to get info about partitions.';
+            if (response.hasOwnProperty('statusCode')) {
+              errorMessage += '\nStatus code: ' + response.statusCode;
+            }
+            if (response.hasOwnProperty('statusMessage')) {
+              errorMessage += '\nStatus message: ' + response.statusMessage;
+            }
+            callback(errorMessage, null);
           }
-          callback(err || 'error', code);
         }
       });
     },


### PR DESCRIPTION
Getting partition info happens when getting the event processor and
issues in the access key or policies come up as a result to this call.

After this commit, more information about the failure is tried to be
passed upstream so that the caller could get better details about the
error condition.

Fixes #20.
